### PR TITLE
Remove health check from Docker Compose configurations

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -18,9 +18,3 @@ services:
         reservations:
           cpus: "2.0"
           memory: 12G
-    healthcheck:
-      test: ["CMD", "/usr/local/bin/sender.sh"]
-      interval: 9s
-      timeout: 10s
-      start_period: 60s
-      retries: 3


### PR DESCRIPTION
It is already included in the [Dockerfile](https://github.com/ivukotic/v4A/blob/8d27c8cd5f82dd4136a7688599c37fd7d0a4a79e/Dockerfile#L18).